### PR TITLE
Add basic unit tests for signal components

### DIFF
--- a/tests/test_feature_pipeline.py
+++ b/tests/test_feature_pipeline.py
@@ -1,0 +1,19 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import pytest
+from collections import deque
+from core.feature_pipeline import generate_live_features, Z_SCORE_WINDOW
+
+
+def test_generate_live_features_structure():
+    window = deque(maxlen=Z_SCORE_WINDOW)
+    features = generate_live_features(30000.0, 2000.0, 0.066, window)
+    expected_keys = {
+        'btc_usd', 'eth_usd', 'eth_btc', 'implied_ethbtc', 'spread',
+        'spread_zscore', 'vol_spread', 'spread_kalman', 'spread_ewma',
+        'btc_vol', 'eth_vol', 'ethbtc_vol', 'momentum_btc', 'momentum_eth',
+        'rolling_corr', 'vol_ratio', 'spread_slope'
+    }
+    assert set(features.keys()) == expected_keys
+
+

--- a/tests/test_mlfilter.py
+++ b/tests/test_mlfilter.py
@@ -1,0 +1,31 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import pandas as pd
+import joblib
+from sklearn.ensemble import RandomForestClassifier
+from utils.filters import MLFilter
+import tempfile
+
+
+def test_mlfilter_predicts_with_sample_model(tmp_path):
+    # create simple training data
+    X = pd.DataFrame({
+        'f1': [0, 1, 2],
+        'f2': [0, 1, 2],
+        'f3': [0, 1, 2]
+    })
+    y = [0, 1, 2]
+    model = RandomForestClassifier(n_estimators=5, random_state=1)
+    model.fit(X, y)
+
+    model_path = tmp_path / 'model.pkl'
+    joblib.dump(model, model_path)
+
+    filt = MLFilter(str(model_path))
+    test_features = pd.DataFrame({'f1': [2], 'f2': [2], 'f3': [2]})
+    confidence, signal = filt.predict_with_confidence(test_features)
+
+    assert 0.0 <= confidence <= 1.0
+    assert signal == 1  # class 2 should map to signal 1
+
+

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -1,0 +1,28 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import csv
+import os
+from datetime import datetime
+from core import trade_logger
+
+
+def test_logging_functions(tmp_path, monkeypatch):
+    signal_path = tmp_path / "signal.csv"
+    exec_path = tmp_path / "exec.csv"
+    monkeypatch.setattr(trade_logger, "LOG_FILE", str(signal_path))
+    monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(exec_path))
+
+    ts = datetime.utcnow()
+    trade_logger.log_signal_event(ts, 1.0, 0.9, 1.2, 1, 1, "test")
+    trade_logger.log_execution_event(ts, "BTCUSDT", 1, 50000, 0.9, 0.8, "bull", 0.1, 0.2, 1.2, 0.0)
+
+    with open(signal_path) as f:
+        rows = list(csv.reader(f))
+    assert rows and len(rows[0]) >= 10
+
+    with open(exec_path) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert rows and rows[0]["pair"] == "BTCUSDT"
+
+


### PR DESCRIPTION
## Summary
- add tests for `generate_live_features`
- test MLFilter predictions with a tiny RandomForest model
- verify logging to CSV via `log_signal_event` and `log_execution_event`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418f56089c832b985b09d951aaedf6