### PR TITLE
Fix default config headers

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,3 @@
- codex/integrate-ml-models-and-execution-engine
 # Default configuration for backtest sweeps
 backtest:
   sell_thresholds: [0.80, 0.83, 0.86, 0.89, 0.92, 0.95, 0.98]
@@ -43,4 +42,3 @@ regime_defaults:
 
 websocket:
   binance_url: "wss://stream.binance.com:9443/stream?streams=btcusdt@ticker/ethusdt@ticker/ethbtc@ticker"
- main


### PR DESCRIPTION
## Summary
- clean up `config/default.yaml` so it starts with a comment header and ends at the binance URL entry

## Testing
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68419d594a9c832bbbc5c05353a61459