### PR TITLE
Enhance entry gating logic

### DIFF
--- a/core/feature_pipeline.py
+++ b/core/feature_pipeline.py
@@ -119,4 +119,12 @@ def generate_features_from_csvs(csv_paths):
     return pd.DataFrame(features)
 
 def generate_live_features(btc_price, eth_price, ethbtc_price, windows):
+    """Generate features from live prices using provided rolling windows."""
+    if isinstance(windows, deque):
+        windows = {
+            "spread": windows,
+            "btc": deque(maxlen=Z_SCORE_WINDOW),
+            "eth": deque(maxlen=Z_SCORE_WINDOW),
+            "ethbtc": deque(maxlen=Z_SCORE_WINDOW),
+        }
     return compute_triangle_features(btc_price, eth_price, ethbtc_price, windows)


### PR DESCRIPTION
## Summary
- enforce strong trade entry gates with confidence, cointegration and z-score thresholds
- add helper to check gate conditions
- extend trade cooldown timing and apply after entries
- support deque input for `generate_live_features`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68419f260684832b81d96c65906c72ce