### PR TITLE
Implement smart trade lifecycle with metrics

### DIFF
--- a/core/prom_metrics.py
+++ b/core/prom_metrics.py
@@ -1,0 +1,9 @@
+from prometheus_client import Gauge, Counter, start_http_server
+
+CONFIDENCE_SCORE = Gauge('confidence_score', 'Latest confidence score from model')
+TRADE_PNL = Gauge('trade_pnl', 'Realized PnL percentage from last trade')
+EXIT_REASON_COUNTS = Counter('exit_reason_counts', 'Number of exits by reason', ['reason'])
+
+def start_metrics_server(port: int = 8000):
+    """Start Prometheus metrics server."""
+    start_http_server(port)

--- a/core/retrain_scheduler.py
+++ b/core/retrain_scheduler.py
@@ -1,0 +1,9 @@
+import asyncio
+import subprocess
+import sys
+
+async def schedule_retrain(interval_hours: int = 24):
+    """Periodically trigger model retraining."""
+    while True:
+        await asyncio.sleep(interval_hours * 3600)
+        subprocess.call([sys.executable, "tools/retrain_all_models.py"])

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -13,17 +13,17 @@ async def test_tp_hit(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(log_path))
 
     q = asyncio.Queue()
-    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9)
+    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0)
     manager = TradeManager(state, q, timeout_seconds=5)
     task = asyncio.create_task(manager.start())
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9))
-    q.put_nowait((datetime.utcnow(), 100.0 * (1 + 0.0061) + 0.1, 0.8, 0.9))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
+    q.put_nowait((datetime.utcnow(), 101.0, 0.8, 0.9, -0.1, -0.1))
     await asyncio.sleep(0.2)
     task.cancel()
-    assert state.exit_reason == "TP_HIT"
+    assert state.exit_reason == "TP_REVERSION"
     with open(log_path) as f:
         rows = list(csv.DictReader(f))
-    assert rows[0]["exit_reason"] == "TP_HIT"
+    assert rows[0]["exit_reason"] == "TP_REVERSION"
 
 @pytest.mark.asyncio
 async def test_sl_hit(tmp_path, monkeypatch):
@@ -31,14 +31,14 @@ async def test_sl_hit(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(log_path))
 
     q = asyncio.Queue()
-    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9)
+    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0)
     manager = TradeManager(state, q, timeout_seconds=5)
     task = asyncio.create_task(manager.start())
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9))
-    q.put_nowait((datetime.utcnow(), 100.0 * (1 - 0.0019) - 0.1, 0.8, 0.9))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
+    q.put_nowait((datetime.utcnow(), 99.0, 0.8, 0.9, 3.0, -0.2))
     await asyncio.sleep(0.2)
     task.cancel()
-    assert state.exit_reason == "SL_HIT"
+    assert state.exit_reason == "TREND_COLLAPSE"
 
 @pytest.mark.asyncio
 async def test_confidence_drop(tmp_path, monkeypatch):
@@ -46,14 +46,14 @@ async def test_confidence_drop(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(log_path))
 
     q = asyncio.Queue()
-    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9)
+    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0)
     manager = TradeManager(state, q, timeout_seconds=5)
     task = asyncio.create_task(manager.start())
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9))
-    q.put_nowait((datetime.utcnow(), 100.0, 0.4, 0.9))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.4, 0.9, 3.0, 0.1))
     await asyncio.sleep(0.2)
     task.cancel()
-    assert state.exit_reason == "CONFIDENCE_DROP"
+    assert state.exit_reason == "CONFIDENCE_EXIT"
 
 @pytest.mark.asyncio
 async def test_cointegration_fail(tmp_path, monkeypatch):
@@ -61,14 +61,14 @@ async def test_cointegration_fail(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(log_path))
 
     q = asyncio.Queue()
-    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9)
+    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0)
     manager = TradeManager(state, q, timeout_seconds=5)
     task = asyncio.create_task(manager.start())
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9))
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.6))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.6, 3.0, 0.1))
     await asyncio.sleep(0.2)
     task.cancel()
-    assert state.exit_reason == "COINTEGRATION_FAIL"
+    assert state.exit_reason == "COINTEGRATION_EXIT"
 
 @pytest.mark.asyncio
 async def test_timeout_exit(tmp_path, monkeypatch):
@@ -76,10 +76,10 @@ async def test_timeout_exit(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_logger, "EXECUTION_LOG_FILE", str(log_path))
 
     q = asyncio.Queue()
-    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9)
+    state = TradeState("BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0)
     manager = TradeManager(state, q, timeout_seconds=1)
     task = asyncio.create_task(manager.start())
-    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9))
+    q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
     await asyncio.sleep(1.2)
     task.cancel()
     assert state.exit_reason == "TIMEOUT"


### PR DESCRIPTION
## Summary
- tighten entry gate thresholds and add slope filter
- log confidence metrics to Prometheus and expose exit counters
- manage trades with new lifecycle states
- schedule periodic model retraining hook
- adapt tests for new TradeManager logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9374558832bb7c54292baa3217e