### PR TITLE
Add strategy_mode support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,6 +12,9 @@ backtest:
   seed: 42
   model_path: "ml_model/triangular_rf_model.json"
 
+# Switch between defensive and alpha trading styles
+strategy_mode: defensive
+
 
 model_paths:
   confidence_filter: ml_model/triangular_rf_model.json

--- a/core/trade_manager.py
+++ b/core/trade_manager.py
@@ -32,10 +32,11 @@ class TradeState:
 class TradeManager:
     """Asynchronous manager for open trades."""
 
-    def __init__(self, trade_state: TradeState, price_feed: "asyncio.Queue", timeout_seconds: int = 600):
+    def __init__(self, trade_state: TradeState, price_feed: "asyncio.Queue", timeout_seconds: int = 600, strategy_mode: str = "defensive"):
         self.state = trade_state
         self.feed = price_feed
         self.timeout_seconds = timeout_seconds
+        self.strategy_mode = strategy_mode.lower()
         self._task: Optional[asyncio.Task] = None
         self._active = False
 
@@ -43,7 +44,7 @@ class TradeManager:
         self._tp_target: Optional[float] = None
         self._ratchet_sl: Optional[float] = None
 
-        if self.state.tp_pct > 0:
+        if self.strategy_mode == "alpha" and self.state.tp_pct > 0:
             self._tp_target = self.state.entry_price * (
                 1 + (self.state.direction * self.state.tp_pct) / 100
             )

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -95,7 +95,7 @@ async def test_trailing_tp_exit(tmp_path, monkeypatch):
     state = TradeState(
         "BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0, tp_pct=2.0
     )
-    manager = TradeManager(state, q, timeout_seconds=5)
+    manager = TradeManager(state, q, timeout_seconds=5, strategy_mode="alpha")
     task = asyncio.create_task(manager.start())
     q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
     q.put_nowait((datetime.utcnow(), 101.0, 0.8, 0.9, 3.0, 0.1))
@@ -115,7 +115,7 @@ async def test_sl_ratchet_exit(tmp_path, monkeypatch):
     state = TradeState(
         "BTCUSDT", 1, 100.0, datetime.utcnow(), 0.8, 0.9, 3.0, tp_pct=2.0
     )
-    manager = TradeManager(state, q, timeout_seconds=5)
+    manager = TradeManager(state, q, timeout_seconds=5, strategy_mode="alpha")
     task = asyncio.create_task(manager.start())
     q.put_nowait((datetime.utcnow(), 100.0, 0.8, 0.9, 3.0, 0.1))
     q.put_nowait((datetime.utcnow(), 101.0, 0.8, 0.9, 3.0, 0.1))


### PR DESCRIPTION
## Summary
- add `strategy_mode` option to config
- adapt main logic to use new strategy mode
- enable trailing logic when strategy mode is `alpha`
- pass mode into trade manager
- adjust tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cb7b3c40832ba59e17acddb0171c