### PR TITLE
Fix HOLD signal spam and add toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python retrain_all_models.py
 * Columns:
 
   * `timestamp, spread, confidence, zscore, direction, action, reason, profit, sl, tp, slope, regime`
+* Set environment variable `DISPLAY_HOLD=false` to suppress HOLD log lines.
 
 ---
 


### PR DESCRIPTION
## Summary
- avoid repeated HOLD signals by tracking last state
- add `DISPLAY_HOLD` environment variable to optionally suppress HOLD logs
- document the environment variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cdaafdb8832b8b37e21acae34a88