### PR TITLE
Improve trade signal message

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ python retrain_all_models.py
 ```bash
 python main.py
 ```
+Example output:
+
+```text
+✅ TRADE SIGNAL: BUY BTC/USDT @ 27180.25 | SL: 0.21% | TP: 0.55% | Confidence: 0.93
+```
+
+Set environment variable `DISPLAY_HOLD=false` to hide HOLD lines.
 
 ### Run full model training:
 

--- a/core/execution_engine.py
+++ b/core/execution_engine.py
@@ -43,23 +43,34 @@ def calculate_dynamic_sl_tp(spread_zscore, vol_spread, confidence, regime=None):
 # ────────────────────────────────────────────────────────────────────────
 # 📢 Signal Display Helper
 # ────────────────────────────────────────────────────────────────────────
-def display_signal_info(signal: int, sl_pct: float, tp_pct: float, confidence: float):
-    """Print trade direction with risk parameters, avoiding HOLD spam."""
+def display_signal_info(
+    signal: int,
+    sl_pct: float,
+    tp_pct: float,
+    confidence: float,
+    pair: str | None = None,
+    entry_price: float | None = None,
+):
+    """Print concise BUY/SELL messages and optionally SHOW holds."""
     global _LAST_SIGNAL_STATE
 
-    direction_map = {1: "🟢 BUY", -1: "🔴 SELL", 0: "⚪ HOLD"}
+    direction_map = {1: "BUY", -1: "SELL", 0: "HOLD"}
 
     # Handle HOLD filtering
     if signal == 0:
-        if DISPLAY_HOLD and _LAST_SIGNAL_STATE in (1, -1):
-            msg = f"{direction_map[0]} | SL={sl_pct:.2f}% | TP={tp_pct:.2f}% | Conf={confidence:.2f}"
-            print(msg)
+        if DISPLAY_HOLD and signal != _LAST_SIGNAL_STATE:
+            print("⚪ HOLD")
         _LAST_SIGNAL_STATE = 0
         return
 
     # BUY or SELL
     if signal != _LAST_SIGNAL_STATE:
-        msg = f"{direction_map.get(signal, '⚪ HOLD')} | SL={sl_pct:.2f}% | TP={tp_pct:.2f}% | Conf={confidence:.2f}"
+        pair_fmt = pair.replace("USDT", "/USDT") if pair else ""
+        price_fmt = f" @ {entry_price:.2f}" if entry_price is not None else ""
+        msg = (
+            f"✅ TRADE SIGNAL: {direction_map.get(signal)} {pair_fmt}{price_fmt} "
+            f"| SL: {sl_pct:.2f}% | TP: {tp_pct:.2f}% | Confidence: {confidence:.2f}"
+        )
         print(msg)
     _LAST_SIGNAL_STATE = signal
     # Print paper, don't burn it. No guessing. Enter only when the edge is sharp. Otherwise, hold the trigger.

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def color_text(text, color):
     return f"{colors.get(color,'')}{text}{colors['reset']}"
 
 def print_startup():
-    print(color_text("✅ XAlgo [Signal Engine Started]\n", "green"))
+    print(color_text("✅ XAlgo Signal Engine Ready – Awaiting High-Confidence Trades...\n", "green"))
     print(color_text("📊 ACTIVE MODELS:", "yellow"))
     print(f"   • Confidence Filter       → {os.path.basename(MODEL_PATHS.get('confidence_filter', 'triangular_rf_model.json'))}")
     print(f"   • Pair Selector           → {os.path.basename(MODEL_PATHS.get('pair_selector', 'pair_selector_model.json'))}")
@@ -302,7 +302,14 @@ def process_tick(timestamp, btc_price, eth_price, ethbtc_price):
             take_profit=tp,
         )
 
-        display_signal_info(direction, config["SL_PERCENT"], config["TP_PERCENT"], confidence)
+        display_signal_info(
+            direction,
+            config["SL_PERCENT"],
+            config["TP_PERCENT"],
+            confidence,
+            pair=pair,
+            entry_price=entry_price,
+        )
         cluster.clear()
         reverse_cluster_map[pair].clear()
         locked_until[pair] = timestamp + timedelta(seconds=TRADE_LOCK_SECONDS)


### PR DESCRIPTION
## Summary
- show concise trade signals with pair, entry price, SL/TP and confidence
- tweak startup print line
- document example signal in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d86fd138832b86be2c9188e0843f