### PR TITLE
Add Prometheus metrics server

### DIFF
--- a/utils/metrics_server.py
+++ b/utils/metrics_server.py
@@ -1,0 +1,27 @@
+from prometheus_client import Gauge, start_http_server
+import logging
+
+# Define Prometheus gauges
+confidence_gauge = Gauge(
+    "xalgo_confidence_score",
+    "Latest confidence score from model",
+)
+cointegration_gauge = Gauge(
+    "xalgo_cointegration_score",
+    "Latest cointegration stability score",
+)
+regime_gauge = Gauge(
+    "xalgo_regime_label",
+    "Current regime label as integer",
+)
+
+
+def start_metrics_server(port: int = 8001) -> None:
+    """Start Prometheus metrics server on the specified port."""
+    try:
+        start_http_server(port)
+        logging.info(
+            "\u2705 Prometheus metrics running at http://localhost:%d/metrics", port
+        )
+    except OSError as exc:  # Port already in use or other socket errors
+        logging.error("Failed to start metrics server on port %d: %s", port, exc)


### PR DESCRIPTION
## Summary
- create `utils/metrics_server` with gauges and server startup
- start metrics server in `main.py`
- update confidence, cointegration and regime gauges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429a30c9b4832b947e98be954fcb06