### PR TITLE
Refactor config and unify thresholds

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,40 +1,39 @@
 # Default configuration for backtest sweeps
 backtest:
-  sell_thresholds: [0.80, 0.83, 0.86, 0.89, 0.92, 0.95, 0.98]
-  buy_thresholds: [0.70, 0.73, 0.76, 0.79, 0.82, 0.85]
-  sl_percents: [0.15, 0.17, 0.19]
-  tp_percents: [0.54, 0.61, 0.68, 0.75]
-  # Newly tuned threshold ranges used for comparison backtests
-  sell_thresholds_new: [0.85, 0.88, 0.91, 0.94]
-  buy_thresholds_new: [0.72, 0.75, 0.78, 0.81]
-  sl_percents_new: [0.12, 0.14, 0.16]
-  tp_percents_new: [0.65, 0.72, 0.79]
-  seed: 42
-  model_path: "ml_model/triangular_rf_model.json"
+  defaults:
+    seed: 42
+    model_path: "ml_model/triangular_rf_model.json"
+    use_regime_defaults: false
+  grid:
+    sell_thresholds: [0.80, 0.83, 0.86, 0.89, 0.92, 0.95, 0.98]
+    buy_thresholds: [0.70, 0.73, 0.76, 0.79, 0.82, 0.85]
+    sl_percents: [0.15, 0.17, 0.19]
+    tp_percents: [0.54, 0.61, 0.68, 0.75]
+    sell_thresholds_new: [0.85, 0.88, 0.91, 0.94]
+    buy_thresholds_new: [0.72, 0.75, 0.78, 0.81]
+    sl_percents_new: [0.12, 0.14, 0.16]
+    tp_percents_new: [0.65, 0.72, 0.79]
 
 # Switch between defensive and alpha trading styles
 strategy_mode: alpha # Options: defensive, alpha
 trailing_tp_offset_pct: 0.002
 
 
-model_paths:
+models:
   confidence_filter: ml_model/triangular_rf_model.json
   pair_selector: ml_model/pair_selector_model.json
   cointegration_model: ml_model/cointegration_score_model.json
   regime_classifier: ml_model/regime_classifier.json
 
-zscore_thresholds:
-  min_buy: 1.0
-  min_sell: -1.0
-
 entry_thresholds:
   confidence_min: 0.75
   cointegration_min: 0.75
-  zscore_min: 2.0
-  zscore_min_flat: 1.8
   min_volatility: 0.02
   entry_slope_min: 0.01
   dynamic_zscore_min: 1.5
+
+use_dynamic_sl_tp: true
+trailing_tp_enabled: false
 
 # Profit-oriented thresholds with R:R tuning for Phase IV+
 regime_defaults:

--- a/config_thresholds.py
+++ b/config_thresholds.py
@@ -1,0 +1,18 @@
+import yaml
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parent / 'config' / 'default.yaml'
+with open(CONFIG_PATH, 'r') as f:
+    CONFIG = yaml.safe_load(f)
+
+ENTRY_THRESHOLDS = CONFIG.get('entry_thresholds', {})
+REGIME_DEFAULTS = CONFIG.get('regime_defaults', {})
+MODELS = CONFIG.get('models', {})
+BACKTEST_CFG = CONFIG.get('backtest', {})
+USE_DYNAMIC_SL_TP = CONFIG.get('use_dynamic_sl_tp', True)
+TRAILING_TP_ENABLED = CONFIG.get('trailing_tp_enabled', False)
+TRAILING_TP_OFFSET_PCT = CONFIG.get('trailing_tp_offset_pct', 0.002)
+
+
+def get_dynamic_zscore_min() -> float:
+    return float(ENTRY_THRESHOLDS.get('dynamic_zscore_min', 1.5))

--- a/core/prom_metrics.py
+++ b/core/prom_metrics.py
@@ -8,6 +8,7 @@ TRADE_PNL = Gauge('trade_pnl', 'Realized PnL percentage from last trade')
 # --- Counters ---
 EXIT_REASON_COUNTS = Counter('exit_reason_counts', 'Number of exits by reason', ['reason'])
 MISSED_OPPORTUNITIES = Counter('missed_opportunities', 'Signals vetoed by entry filters')
+ENTRY_REASON_COUNTS = Counter('entry_reason_counts', 'Number of entry decisions by reason', ['reason'])
 
 def start_metrics_server(port: int = 8000):
     """Start Prometheus metrics server."""

--- a/core/trade_logger.py
+++ b/core/trade_logger.py
@@ -2,6 +2,7 @@ import csv
 import os
 import logging
 from datetime import datetime, timezone
+from .prom_metrics import ENTRY_REASON_COUNTS
 
 LOG_FILE = "logs/signal_log.csv"
 EXECUTION_LOG_FILE = "logs/execution_log.csv"
@@ -59,6 +60,9 @@ def log_signal_event(
         with open(LOG_FILE, "a", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writerow(log_data)
+
+        if reason:
+            ENTRY_REASON_COUNTS.labels(reason).inc()
 
     except Exception as e:
         logging.error(f"❌ Failed to log signal: {e}")

--- a/core/trade_manager.py
+++ b/core/trade_manager.py
@@ -40,6 +40,7 @@ class TradeManager:
         timeout_seconds: int = 600,
         strategy_mode: str = "defensive",
         trailing_offset_pct: float = 0.002,
+        trailing_enabled: bool = False,
     ):
         self.state = trade_state
         self.feed = price_feed
@@ -48,16 +49,17 @@ class TradeManager:
         self._task: Optional[asyncio.Task] = None
         self._active = False
 
+        self.trailing_enabled = trailing_enabled
         self.trailing_active = False
         self._tp_target: Optional[float] = None
         self.trailing_offset_pct = trailing_offset_pct
         self._ratchet_sl: Optional[float] = None
-        self._tp_target = (
-            self.state.entry_price
-            * (1 + (self.state.direction * self.state.tp_pct) / 100)
-            if self.state.tp_pct > 0
-            else None
-        )
+        if self.trailing_enabled and self.state.tp_pct > 0:
+            self._tp_target = self.state.entry_price * (
+                1 + (self.state.direction * self.state.tp_pct) / 100
+            )
+        else:
+            self._tp_target = None
 
     async def start(self):
         self._active = True


### PR DESCRIPTION
## Summary
- refactor configuration schema and move model paths under `models`
- centralize threshold loading via `config_thresholds.py`
- update main engine and backtest to use new config layout
- add entry reason Prometheus metric and expose from logger
- support optional trailing TP in trade manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dcff48a4832bb738d476cb85eacd