### PR TITLE
Add default regime fallback

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -73,6 +73,11 @@ regime_defaults:
     thr_buy: 0.70
     sl_percent: 0.30
     tp_percent: 0.85
+  default:
+    base_thr_sell: 0.95
+    thr_buy: 0.75
+    sl_percent: 0.25
+    tp_percent: 0.80
 
 websocket:
   binance_url: "wss://stream.binance.com:9443/stream?streams=btcusdt@ticker/ethusdt@ticker/ethbtc@ticker"

--- a/main.py
+++ b/main.py
@@ -156,7 +156,8 @@ def ensure_datetime(ts):
     return datetime.utcnow().replace(tzinfo=pytz.utc).astimezone(NAIROBI_TZ)
 
 def get_live_config(regime, direction):
-    best = BEST_CONFIGS.get(regime, BEST_CONFIGS["flat"])
+    # Use "default" fallback if regime key is not found
+    best = BEST_CONFIGS.get(regime, BEST_CONFIGS.get("default", BEST_CONFIGS["flat"]))
 
     sl = float(best["sl_percent"])
     tp = float(best["tp_percent"])
@@ -165,6 +166,9 @@ def get_live_config(regime, direction):
     if STRATEGY_MODE == "alpha":
         sl *= 0.7
         tp *= 0.65
+
+    # Enforce max TP cap
+    tp = min(tp, 1.00)
 
     return {
         "MASTER_CONVICTION_THRESHOLD": threshold,


### PR DESCRIPTION
## Summary
- extend `regime_defaults` with a `default` entry
- update `get_live_config` to use the new fallback and cap TP at 1.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dd77641c832baeeeba1784f8da23