### PR TITLE
Implement memory subsystem

### DIFF
--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,17 @@
+"""Memory subsystem for XAlgo."""
+
+from .memory_core import MemoryCore
+from .ghost_tracker import GhostTracker
+from .signal_memory import SignalMemory, SignalRecord
+from .regime_recall import RegimeRecall, RegimeOutcome
+from .post_entry_watcher import PostEntryWatcher
+
+__all__ = [
+    "MemoryCore",
+    "GhostTracker",
+    "SignalMemory",
+    "SignalRecord",
+    "RegimeRecall",
+    "RegimeOutcome",
+    "PostEntryWatcher",
+]

--- a/memory/ghost_tracker.py
+++ b/memory/ghost_tracker.py
@@ -1,0 +1,37 @@
+"""Order book ghost order detection."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from .memory_core import MemoryCore
+
+
+class GhostTracker:
+    """Track ghost orders that appear then vanish."""
+
+    def __init__(self, memory: MemoryCore) -> None:
+        self.memory = memory
+        self._last_book: Dict[str, Dict[float, float]] = defaultdict(dict)
+
+    def update_order_book(self, pair: str, bids: List[Tuple[float, float]], asks: List[Tuple[float, float]]) -> None:
+        """Process order book snapshot.
+
+        Parameters
+        ----------
+        pair: trading pair symbol
+        bids/asks: lists of (price, volume)
+        """
+        prev = self._last_book[pair]
+        current = {price: vol for price, vol in bids + asks}
+
+        # detect vanished orders
+        for price, vol in prev.items():
+            if price not in current:
+                self.memory.record_ghost(price)
+        self._last_book[pair] = current
+        self.memory.save_all()
+
+
+__all__ = ["GhostTracker"]

--- a/memory/memory_core.py
+++ b/memory/memory_core.py
@@ -1,0 +1,97 @@
+"""Core memory management for XAlgo's adaptive modules."""
+
+from __future__ import annotations
+
+import json
+import pickle
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Any
+
+DEFAULT_GHOST_PATH = Path("ghost_heatmap.json")
+DEFAULT_SIGNAL_PATH = Path("signal_memory.pkl")
+DEFAULT_REGIME_PATH = Path("regime_profile.json")
+
+
+class MemoryCore:
+    """Container for all persistent memory stores."""
+
+    def __init__(
+        self,
+        ghost_path: Path = DEFAULT_GHOST_PATH,
+        signal_path: Path = DEFAULT_SIGNAL_PATH,
+        regime_path: Path = DEFAULT_REGIME_PATH,
+        signal_maxlen: int = 1000,
+    ) -> None:
+        self.ghost_path = ghost_path
+        self.signal_path = signal_path
+        self.regime_path = regime_path
+
+        self.ghost_heatmap: Dict[str, int] = {}
+        self.signal_memory: Deque[dict[str, Any]] = deque(maxlen=signal_maxlen)
+        self.regime_profile: Dict[str, Dict[str, Any]] = {}
+
+        self._load_all()
+
+    # ------------------------------------------------------------------
+    # Loading / saving
+    # ------------------------------------------------------------------
+    def _load_all(self) -> None:
+        self.ghost_heatmap = self._load_json(self.ghost_path, {})
+        self.regime_profile = self._load_json(self.regime_path, {})
+        if self.signal_path.exists():
+            try:
+                with open(self.signal_path, "rb") as f:
+                    self.signal_memory = pickle.load(f)
+            except Exception:
+                self.signal_memory = deque(maxlen=self.signal_memory.maxlen)
+        else:
+            self.signal_memory = deque(maxlen=self.signal_memory.maxlen)
+
+    def save_all(self) -> None:
+        self._save_json(self.ghost_path, self.ghost_heatmap)
+        self._save_json(self.regime_path, self.regime_profile)
+        try:
+            with open(self.signal_path, "wb") as f:
+                pickle.dump(self.signal_memory, f)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _load_json(path: Path, default: dict) -> dict:
+        if path.exists():
+            try:
+                with open(path) as f:
+                    return json.load(f)
+            except Exception:
+                return default.copy()
+        return default.copy()
+
+    @staticmethod
+    def _save_json(path: Path, data: dict) -> None:
+        try:
+            with open(path, "w") as f:
+                json.dump(data, f)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Update helpers
+    # ------------------------------------------------------------------
+    def record_ghost(self, price: float) -> None:
+        key = f"{price:.2f}"
+        self.ghost_heatmap[key] = self.ghost_heatmap.get(key, 0) + 1
+
+    def add_signal(self, entry: dict[str, Any]) -> None:
+        self.signal_memory.append(entry)
+
+    def update_regime(self, regime: str, outcome: dict[str, Any]) -> None:
+        prof = self.regime_profile.setdefault(regime, {"trades": 0, "wins": 0, "losses": 0})
+        prof["trades"] += 1
+        if outcome.get("win"):
+            prof["wins"] += 1
+        else:
+            prof["losses"] += 1
+
+
+__all__ = ["MemoryCore"]

--- a/memory/memory_dash.py
+++ b/memory/memory_dash.py
@@ -1,0 +1,33 @@
+"""Minimal CLI to inspect memory state."""
+
+from __future__ import annotations
+
+import argparse
+from pprint import pprint
+
+from .memory_core import MemoryCore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect XAlgo memory stores")
+    parser.add_argument("--save", action="store_true", help="Force save on exit")
+    args = parser.parse_args()
+
+    mem = MemoryCore()
+    print("\nGhost Heatmap:")
+    pprint(mem.ghost_heatmap)
+
+    print("\nSignal Memory (last 5):")
+    for item in list(mem.signal_memory)[-5:]:
+        pprint(item)
+
+    print("\nRegime Profile:")
+    pprint(mem.regime_profile)
+
+    if args.save:
+        mem.save_all()
+        print("\nMemory saved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/post_entry_watcher.py
+++ b/memory/post_entry_watcher.py
@@ -1,0 +1,61 @@
+"""Monitor trades post-entry for early exit cues."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from typing import Optional, Callable, Awaitable
+
+from .memory_core import MemoryCore
+
+
+class PostEntryWatcher:
+    """Watch confidence decay after trade entry."""
+
+    def __init__(
+        self,
+        memory: MemoryCore,
+        drop_threshold: float = 0.3,
+        drop_window: int = 30,
+        check_interval: float = 2.0,
+    ) -> None:
+        self.memory = memory
+        self.drop_threshold = drop_threshold
+        self.drop_window = timedelta(seconds=drop_window)
+        self.check_interval = check_interval
+        self._active = False
+        self._task: Optional[asyncio.Task] = None
+        self._updates: list[tuple[datetime, float]] = []
+
+    def update_confidence(self, ts: datetime, confidence: float) -> None:
+        self._updates.append((ts, confidence))
+        cutoff = ts - self.drop_window
+        self._updates = [u for u in self._updates if u[0] >= cutoff]
+
+    async def start(self, exit_callback: Callable[[], Awaitable[None]]) -> None:
+        self._active = True
+        self._task = asyncio.create_task(self._run(exit_callback))
+
+    async def stop(self) -> None:
+        self._active = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _run(self, exit_callback: Callable[[], Awaitable[None]]) -> None:
+        while self._active:
+            await asyncio.sleep(self.check_interval)
+            if len(self._updates) < 2:
+                continue
+            start_conf = self._updates[0][1]
+            latest_conf = self._updates[-1][1]
+            if start_conf - latest_conf >= self.drop_threshold:
+                self.memory.add_signal({"regret_trade": True})
+                await exit_callback()
+                break
+
+
+__all__ = ["PostEntryWatcher"]

--- a/memory/regime_recall.py
+++ b/memory/regime_recall.py
@@ -1,0 +1,39 @@
+"""Market regime profiling and recall logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+from .memory_core import MemoryCore
+
+
+@dataclass
+class RegimeOutcome:
+    timestamp: datetime
+    regime: str
+    win: bool
+    pnl_pct: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["timestamp"] = self.timestamp.isoformat()
+        return d
+
+
+class RegimeRecall:
+    """Track signal performance per market regime."""
+
+    def __init__(self, memory: MemoryCore) -> None:
+        self.memory = memory
+
+    def log_outcome(self, outcome: RegimeOutcome) -> None:
+        self.memory.update_regime(outcome.regime, {"win": outcome.win})
+        self.memory.save_all()
+
+    def get_profile(self) -> Dict[str, Any]:
+        return self.memory.regime_profile
+
+
+__all__ = ["RegimeOutcome", "RegimeRecall"]

--- a/memory/signal_memory.py
+++ b/memory/signal_memory.py
@@ -1,0 +1,42 @@
+"""Signal event memory for performance tracking."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Deque, Dict, Any, Optional
+
+from .memory_core import MemoryCore
+
+
+@dataclass
+class SignalRecord:
+    timestamp: datetime
+    features: Dict[str, Any]
+    outcome: Optional[Dict[str, Any]] = None
+    confidence: float | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["timestamp"] = self.timestamp.isoformat()
+        return d
+
+
+class SignalMemory:
+    """Circular memory of signal outcomes."""
+
+    def __init__(self, memory: MemoryCore, maxlen: int = 1000) -> None:
+        self.memory = memory
+        if not isinstance(self.memory.signal_memory, deque) or self.memory.signal_memory.maxlen != maxlen:
+            self.memory.signal_memory = deque(self.memory.signal_memory, maxlen=maxlen)
+
+    def log_signal(self, record: SignalRecord) -> None:
+        self.memory.signal_memory.append(record.to_dict())
+        self.memory.save_all()
+
+    def recall(self) -> Deque[dict]:
+        return self.memory.signal_memory
+
+
+__all__ = ["SignalRecord", "SignalMemory"]

--- a/tests/test_memory_modules.py
+++ b/tests/test_memory_modules.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from memory import MemoryCore, SignalRecord, SignalMemory, RegimeRecall, RegimeOutcome
+
+
+def test_signal_memory_roundtrip(tmp_path):
+    mem = MemoryCore(signal_path=tmp_path / "sig.pkl")
+    sm = SignalMemory(mem, maxlen=5)
+
+    rec = SignalRecord(timestamp=datetime.utcnow(), features={"a": 1}, confidence=0.9)
+    sm.log_signal(rec)
+
+    assert len(mem.signal_memory) == 1
+    mem.save_all()
+
+    mem2 = MemoryCore(signal_path=tmp_path / "sig.pkl")
+    assert len(mem2.signal_memory) == 1
+
+
+def test_regime_recall(tmp_path):
+    mem = MemoryCore(regime_path=tmp_path / "reg.json")
+    rr = RegimeRecall(mem)
+    out = RegimeOutcome(timestamp=datetime.utcnow(), regime="bull", win=True, pnl_pct=1.0)
+    rr.log_outcome(out)
+    profile = rr.get_profile()
+    assert profile["bull"]["wins"] == 1


### PR DESCRIPTION
## Summary
- add memory subsystem with storage and recall logic
- track ghost orders, signal outcomes, regime performance and post-entry confidence
- expose minimal CLI for inspecting memory
- tests for memory roundtrip and regime profiling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684439bab0a8832b8a56f4b476f94041