### PR TITLE
Implement meta reinforcement learning for adaptive tuning

### DIFF
--- a/core/prom_metrics.py
+++ b/core/prom_metrics.py
@@ -4,11 +4,25 @@ from prometheus_client import Gauge, Counter, start_http_server
 CONFIDENCE_SCORE = Gauge('confidence_score', 'Latest confidence score from model')
 COINTEGRATION_STABILITY = Gauge('cointegration_stability', 'Latest cointegration stability score')
 TRADE_PNL = Gauge('trade_pnl', 'Realized PnL percentage from last trade')
+TUNED_CONFIDENCE_THRESHOLD = Gauge(
+    'tuned_confidence_threshold',
+    'Current tuned confidence threshold'
+)
+REGIME_TRADE_SUCCESS_RATE = Gauge(
+    'regime_trade_success_rate',
+    'Current win rate per regime',
+    ['regime']
+)
 
 # --- Counters ---
 EXIT_REASON_COUNTS = Counter('exit_reason_counts', 'Number of exits by reason', ['reason'])
 MISSED_OPPORTUNITIES = Counter('missed_opportunities', 'Signals vetoed by entry filters')
 ENTRY_REASON_COUNTS = Counter('entry_reason_counts', 'Number of entry decisions by reason', ['reason'])
+META_FALLBACK_USED_TOTAL = Counter('meta_fallback_used_total', 'Fallback config usage count')
+CONFIG_OVERFIT_BLOCK_COUNT = Counter(
+    'config_overfit_block_count',
+    'Tuning updates blocked due to overfitting risk'
+)
 
 def start_metrics_server(port: int = 8000):
     """Start Prometheus metrics server."""

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,11 +1,12 @@
 """Memory subsystem for XAlgo."""
 
-from .memory_core import MemoryCore
+from .memory_core import MemoryCore, schedule_tuning_cycle
 from .ghost_tracker import GhostTracker
 from .signal_memory import SignalMemory, SignalRecord
 from .regime_recall import RegimeRecall, RegimeOutcome
 from .post_entry_watcher import PostEntryWatcher
 from .auto_tuner import AutoTuner, run_tuning_cycle, get_tuned_thresholds
+from .meta_rl import MetaReinforcer
 from .replay_engine import ReplayEngine
 
 __all__ = [
@@ -20,4 +21,6 @@ __all__ = [
     "run_tuning_cycle",
     "get_tuned_thresholds",
     "ReplayEngine",
+    "MetaReinforcer",
+    "schedule_tuning_cycle",
 ]

--- a/memory/auto_tuner.py
+++ b/memory/auto_tuner.py
@@ -2,19 +2,39 @@
 
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+import logging
+from pathlib import Path
 
 import numpy as np
 
 from .memory_core import MemoryCore
+from .meta_rl import MetaReinforcer
+from core.prom_metrics import (
+    CONFIG_OVERFIT_BLOCK_COUNT,
+    TUNED_CONFIDENCE_THRESHOLD,
+)
+
+
+GUARD_LOG = Path("logs/tuning_guard.log")
+logger = logging.getLogger(__name__)
 
 
 class AutoTuner:
     """Analyze signal history and update regime thresholds."""
 
-    def __init__(self, memory: MemoryCore, min_win_rate: float = 0.6) -> None:
+    MIN_DELTA = 0.05
+
+    def __init__(
+        self,
+        memory: MemoryCore,
+        min_win_rate: float = 0.6,
+        meta: Optional[MetaReinforcer] = None,
+    ) -> None:
         self.memory = memory
         self.min_win_rate = min_win_rate
+        self.meta = meta
 
     def run(self) -> Dict[str, Dict[str, Any]]:
         records = list(self.memory.signal_memory)
@@ -25,8 +45,9 @@ class AutoTuner:
             by_regime.setdefault(regime, []).append(rec)
 
         for regime, items in by_regime.items():
-            confidences = []
-            wins = []
+            confidences: list[float] = []
+            wins: list[bool] = []
+            returns: list[float] = []
             for it in items:
                 conf = it.get("confidence")
                 outcome = it.get("outcome", {})
@@ -34,7 +55,31 @@ class AutoTuner:
                     continue
                 confidences.append(float(conf))
                 wins.append(bool(outcome.get("win", False)))
+                returns.append(float(outcome.get("pnl_pct", 0.0)))
             if not confidences:
+                continue
+
+            profile = self.memory.regime_profile.get(regime, {})
+            if profile.get("trades", 0) < 50:
+                CONFIG_OVERFIT_BLOCK_COUNT.inc()
+                try:
+                    GUARD_LOG.parent.mkdir(parents=True, exist_ok=True)
+                    with open(GUARD_LOG, "a") as f:
+                        f.write(f"{regime}:blocked_low_trades\n")
+                except Exception:
+                    pass
+                continue
+
+            new_win_rate = float(sum(wins)) / len(wins)
+            old_win_rate = profile.get("wins", 0) / max(profile.get("trades", 1), 1)
+            if new_win_rate <= old_win_rate + self.MIN_DELTA:
+                CONFIG_OVERFIT_BLOCK_COUNT.inc()
+                try:
+                    GUARD_LOG.parent.mkdir(parents=True, exist_ok=True)
+                    with open(GUARD_LOG, "a") as f:
+                        f.write(f"{regime}:blocked_delta\n")
+                except Exception:
+                    pass
                 continue
             conf_arr = np.array(confidences)
             win_arr = np.array(wins)
@@ -43,18 +88,22 @@ class AutoTuner:
                 threshold = float(np.percentile(win_conf, 20))
             else:
                 threshold = float(np.percentile(conf_arr, 80))
-            tuned[regime] = {
-                "thr_buy": max(0.7, round(threshold, 4)),
-            }
+            thr = max(0.7, round(threshold, 4))
+            tuned[regime] = {"thr_buy": thr}
+            TUNED_CONFIDENCE_THRESHOLD.set(thr)
+
+            avg_ret = float(np.mean(returns)) if returns else 0.0
+            if self.meta:
+                self.meta.update_performance(regime, new_win_rate, avg_ret, len(items))
 
         self.memory.tuned_configs = tuned
         self.memory.save_all()
         return tuned
 
 
-def run_tuning_cycle(memory: MemoryCore) -> Dict[str, Dict[str, Any]]:
+def run_tuning_cycle(memory: MemoryCore, meta: Optional[MetaReinforcer] = None) -> Dict[str, Dict[str, Any]]:
     """Convenience wrapper to execute a tuning pass."""
-    tuner = AutoTuner(memory)
+    tuner = AutoTuner(memory, meta=meta)
     return tuner.run()
 
 

--- a/memory/meta_rl.py
+++ b/memory/meta_rl.py
@@ -1,0 +1,56 @@
+"""Meta reinforcement logic for tuning evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Dict
+
+
+@dataclass
+class _Stats:
+    win_rate: float
+    avg_return: float
+    trades: int
+    weight: float = 1.0
+
+
+class MetaReinforcer:
+    """Track tuning performance and adjust trust weights."""
+
+    def __init__(self, fallback_threshold: float = 0.45, min_trades: int = 20) -> None:
+        self.fallback_threshold = fallback_threshold
+        self.min_trades = min_trades
+        self._stats: Dict[str, _Stats] = {}
+
+    def update_performance(self, regime: str, win_rate: float, avg_return: float, trades: int) -> None:
+        """Update performance metrics for a regime."""
+        if trades < self.min_trades:
+            return
+        rec = self._stats.get(regime)
+        if rec is None:
+            rec = _Stats(win_rate=win_rate, avg_return=avg_return, trades=trades)
+            self._stats[regime] = rec
+        else:
+            rec.win_rate = win_rate
+            rec.avg_return = avg_return
+            rec.trades = trades
+        if win_rate < self.fallback_threshold:
+            rec.weight = max(0.0, rec.weight * 0.5)
+        else:
+            rec.weight = min(1.0, rec.weight + 0.1)
+
+    def get_weight(self, regime: str) -> float:
+        """Return current trust weight for a regime."""
+        rec = self._stats.get(regime)
+        return rec.weight if rec else 1.0
+
+    def use_fallback(self, regime: str) -> bool:
+        """Return True if the regime should fall back to defaults."""
+        rec = self._stats.get(regime)
+        return bool(rec and rec.weight == 0.0)
+
+    def to_dict(self) -> Dict[str, Dict[str, float]]:
+        return {k: asdict(v) for k, v in self._stats.items()}
+
+
+__all__ = ["MetaReinforcer"]

--- a/tests/test_meta_rl.py
+++ b/tests/test_meta_rl.py
@@ -1,0 +1,12 @@
+from memory.meta_rl import MetaReinforcer
+
+
+def test_meta_reinforcer_decay():
+    mr = MetaReinforcer(fallback_threshold=0.5, min_trades=10)
+    mr.update_performance("bull", 0.6, 0.1, 20)
+    assert mr.get_weight("bull") > 0.9
+    mr.update_performance("bull", 0.4, -0.1, 30)
+    assert mr.get_weight("bull") < 1.0
+    for _ in range(3):
+        mr.update_performance("bull", 0.3, -0.2, 30)
+    assert mr.get_weight("bull") <= 0.1


### PR DESCRIPTION
## Summary
- implement MetaReinforcer to monitor tuned configs
- add overfitting guards in AutoTuner
- schedule periodic tuning with metrics
- integrate meta RL into main config selection
- expose new Prometheus metrics
- test MetaReinforcer behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444611e044832b9242f49a577a6172